### PR TITLE
Configuration for upgrade to ERDDAP v2.26

### DIFF
--- a/datasets.xml
+++ b/datasets.xml
@@ -47,7 +47,7 @@
 
 <startHeadHtml5><![CDATA[
 <!DOCTYPE html>
-<html lang="en-US">
+<html lang="&langCode;">
 <head>
 <meta charset="UTF-8">
 <title>SalishSeaCast ERDDAP™</title>
@@ -320,12 +320,10 @@ ERDDAP™, Version &erddapVersion;
 ]]>
 </theShortDescriptionHtml>
 
-
 <dataset type="EDDGridFromNcFiles" datasetID="ubcSSnBathymetryV21-08" active="true">
   <reloadEveryNMinutes>10080</reloadEveryNMinutes>
   <updateEveryNMillis>10000</updateEveryNMillis>
-  <!-- <fileDir>/SalishSeaCast/grid/</fileDir> -->
-  <fileDir>/media/doug/warehouse/MEOPAR/grid/</fileDir>
+  <fileDir>/SalishSeaCast/grid/</fileDir>
   <recursive>false</recursive>
   <fileNameRegex>.*bathymetry_202108\.nc$</fileNameRegex>
   <metadataFrom>last</metadataFrom>
@@ -527,8 +525,7 @@ v21-08: same variables,
 <dataset type="EDDGridFromNcFiles" datasetID="ubcSSn2DMeshMaskV21-08" active="true">
   <reloadEveryNMinutes>10080</reloadEveryNMinutes>
   <updateEveryNMillis>10000</updateEveryNMillis>
-  <!-- <fileDir>/SalishSeaCast/grid/</fileDir> -->
-  <fileDir>/media/doug/warehouse/MEOPAR/grid/</fileDir>
+  <fileDir>/SalishSeaCast/grid/</fileDir>
   <recursive>false</recursive>
   <fileNameRegex>.*mesh_mask202108\.nc$</fileNameRegex>
   <metadataFrom>last</metadataFrom>

--- a/datasets.xml
+++ b/datasets.xml
@@ -1,5 +1,30 @@
-<?xml version="1.0" encoding="ISO-8859-1" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <erddapDatasets>
+
+<!-- The tags below are described in setupDatasetsXml.html.
+      The defaults listed below are as of ERDDAP™ v2.00. -->
+<cacheMinutes>60</cacheMinutes>                                     <!-- default=60 -->
+<decompressedCacheMaxGB>10</decompressedCacheMaxGB>                 <!-- default=10 -->
+<decompressedCacheMaxMinutesOld>15</decompressedCacheMaxMinutesOld> <!-- default=15 -->
+<drawLandMask>over</drawLandMask>                                   <!-- "over" or "under" (default) -->
+<graphBackgroundColor></graphBackgroundColor>                       <!-- 0xAARRGGBB, default is 0xffccccff -->
+<loadDatasetsMinMinutes>15</loadDatasetsMinMinutes>                 <!-- usually=default=15 -->
+<loadDatasetsMaxMinutes>60</loadDatasetsMaxMinutes>                 <!-- default=60 -->
+<logLevel>info</logLevel>                                           <!-- "warning" (fewest messages), "info" (default), or "all" (most messages) -->
+<nGridThreads>1</nGridThreads>                                      <!-- default=1 -->
+<nTableThreads>1</nTableThreads>                                    <!-- default=1 -->
+<partialRequestMaxBytes>490000000</partialRequestMaxBytes>          <!-- default=490000000 -->
+<partialRequestMaxCells>10000000</partialRequestMaxCells>           <!-- default=10000000 -->
+<slowDownTroubleMillis>1000</slowDownTroubleMillis>                 <!-- default=1000 -->
+<unusualActivity>10000</unusualActivity>                            <!-- default=10000 -->
+<!-- The defaults for the following tags are in messages.xml. -->
+<standardLicense></standardLicense>
+<standardContact></standardContact>
+<standardDataLicenses></standardDataLicenses>
+<standardDisclaimerOfEndorsement></standardDisclaimerOfEndorsement>
+<standardDisclaimerOfExternalLinks></standardDisclaimerOfExternalLinks>
+<standardGeneralDisclaimer></standardGeneralDisclaimer>
+<standardPrivacyPolicy></standardPrivacyPolicy>
 
 <!-- If you want to refuse requests from certain clients
   (e.g., to fend off a Denial of Service attack or an overly zealous web robot),
@@ -10,10 +35,7 @@
 <requestBlacklist>
   <!-- dataforseo.com, an Estonian SEO company; swamped server with request failures on: -->
   <!-- 22sep23, 1apr24 -->
-  136.243.228.193,136.243.228.179
-  <!-- lcg-ce4.sfu.computecanada.ca; causing time outs due to high memory: -->
-  <!-- 01nov24-05nov24 and 12nov24; blocked on 12nov24 -->
-  <!-- 206.12.127.34 -->
+  136.243.228.193, 136.243.228.179
 </requestBlacklist>
 
 <!-- If you want to prevent specific people from using the email/URL subscription
@@ -23,10 +45,287 @@
 <subscriptionEmailBlacklist>
 </subscriptionEmailBlacklist>
 
+<startHeadHtml5><![CDATA[
+<!DOCTYPE html>
+<html lang="en-US">
+<head>
+<meta charset="UTF-8">
+<title>SalishSeaCast ERDDAP™</title>
+<link rel="shortcut icon" href="&erddapUrl;/images/favicon.ico">
+<link href="&erddapUrl;/images/erddap2.css" rel="stylesheet" type="text/css">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+]]></startHeadHtml5>
+
+<startBodyHtml5><![CDATA[
+<body>
+<table class="compact nowrap" style="width:100%; background-color:#128CB5;">
+  <tr>
+    <td style="text-align:center; width:160px; padding-right: 20px;">
+      <a
+        rel="bookmark"
+        href="https://salishsea.eos.ubc.ca/">
+        <img
+          title="SalishSeaCast"
+          src="&erddapUrl;/images/UBC-MEOPAR-Logos.png" alt="UBC and MEOPAR Logos"
+          style="vertical-align:middle;"/>
+      </a>
+    </td>
+    <td style="text-align:left; font-size:x-large; color:#FFFFFF;">
+      <strong>SalishSeaCast ERDDAP™</strong>
+      <br><small><small><small>Public access to the SalishSeaCast model products</small></small></small>
+    </td>
+    <td style="text-align:right; font-size:small;">
+      &loginInfo; &nbsp; &nbsp;
+      <br>&BroughtToYouBy;
+      <a title="SalishSeaCast" rel="bookmark" href="https://salishsea.eos.ubc.ca/">SalishSeaCast</a>
+      <a title="UBC Earth, Ocean & Atmospheric Sciences" rel="bookmark" href="https://www.eoas.ubc.ca/">UBC EOAS</a>
+      <a title="Marine Environmental Observation Prediction and Response Network" rel="bookmark" href="http://meopar.ca/">MEOPAR</a>
+      <a title="National Oceanic and Atmospheric Administration" rel="bookmark" href="http://www.noaa.gov">NOAA</a>
+      &nbsp; &nbsp;
+    </td>
+  </tr>
+</table>
+]]></startBodyHtml5>
+
+<endBodyHtml5><![CDATA[
+<div class="standard_width">
+<br>&nbsp;
+<hr>
+ERDDAP™, Version &erddapVersion;
+<br><a rel="license" href="&erddapUrl;/legal.html">Disclaimers</a> |
+    <a rel="bookmark" href="&erddapUrl;/legal.html#privacyPolicy">Privacy Policy</a> |
+    <a rel="bookmark" href="&erddapUrl;/legal.html#contact">Contact</a>
+<p>&nbsp;
+<p>&nbsp;
+<p>&nbsp;
+<p>&nbsp;
+<p>&nbsp;
+<p>&nbsp;
+<p>&nbsp;
+<p>&nbsp;
+<p>&nbsp;
+<p>&nbsp;
+<p>&nbsp;
+</div>
+</body>
+]]></endBodyHtml5>
+
+<theShortDescriptionHtml><![CDATA[
+<h1>SalishSeaCast ERDDAP™</h1>
+<p>
+  ERDDAP™ is a data server that gives you a simple, consistent way to download
+  subsets of scientific datasets in common file formats and make graphs and maps.
+</p>
+<p>
+  This particular ERDDAP™ installation has model product datasets from the SalishSeaCast
+  system run by the Mesoscale Ocean and Atmospheric Dynamics (MOAD)
+  group in the Department of Earth, Ocean, and Atmospheric Sciences (EOAS)
+  at the University of British Columbia (UBC).
+  Available datasets include surface and 3D fields of currents, temperature, salinity,
+  sea surface height, biological and chemical tracers from NEMO and FVCOM,
+  and wave fields WaveWatch III®,
+  as well as the Environment and Climate Change Canada (ECCC)
+  High Resolution Deterministic Prediction System (HRDPS)
+  atmospheric model fields used to force the models.
+  Also available are aggregated datasets from selected Ocean Networks Canada (ONC) real-time sensors,
+  and a real-time current dataset from a Vancouver Fraser Port Authority (VFPA) sensor at the 2nd Narrows railway bridge in Vancouver Harbour.
+</p>
+<p>
+  Please see <a href="https://salishsea.eos.ubc.ca/">https://salishsea.eos.ubc.ca/</a>
+  for more information about the model and the SalishSeaCast system.
+</p>
+
+<h2>V21-11 NEMO Model is Live!</h2>
+<p>
+  A new, improved version of the SalishSeaCast NEMO model has been running in near-real-time since 1-Jan-2024.
+  A hindcast from 1-Jan-2007 using that model configuration was completed in late 2023.
+  New NEMO datasets from that model configuration were added to this ERDDAP™ starting in December 2023.
+  They are identified with a <code>V21-11</code> version string in their dataset ids, titles, summaries, etc.
+</p>
+<p>
+  The hindcast was spun up for 5 years with best available forcing and boundary conditions for 2002-2006.
+  The spin-up years are <em>not</em> included in the <code>V21-11</code> datasets.
+</p>
+<p>
+  The rolling forecast datasets are from the <code>V21-11</code> model configuration.
+  The version part of the rolling forecast dataset ids was dropped on 2-Jul-2019 to reflect the fact
+  that those datasets transition smoothly from one model version to the next.
+  Please see the summary metadata item to learn what model version is producing the most recent fields in the rolling forecast datasets.
+</p>
+
+<h3>Changes Between <code>V19-05</code> and <code>V21-11</code></h3>
+<h4>Physics</h4>
+<p>
+  From Stang and Allen, 2024:
+</p>
+<ul>
+  <li>
+    Daily river flows are calculated using continuous gauge records fitted to monthly watersheds
+    from Morrison et al. (2012), which allows for inter-annual variability like winter storms and summer droughts.
+  </li>
+  <li>
+    The bathymetry was improved by adjusting the coastline to the 2-m isobath
+    (previously set to the mean sea level isobath)
+    and then deepening the minimum water depth to 4 m.
+    These changes align the extent of the Fraser River plume more closely with observations.
+    The bathymetry is available in the
+    <a href="https://salishsea.eos.ubc.ca/erddap/info/ubcSSnBathymetryV21-08/index.html">ubcSSnBathymetryV21-08</a>
+    dataset.
+  </li>
+  <li>
+    Coastal wave characterization was improved using WaveWatch III® model results,
+    addressing the small fetch and waves in the Salish Sea (Moore-Maley, 2022).
+    The new parameterization reduces mixing by adjusting the turbulence parameterization surface boundary condition,
+    partially correcting the too salty surface salinities in the Fraser River plume.
+  </li>
+</ul>
+
+<h4>Biology</h4>
+<p>
+  From Suchy, et al, in preparation:
+</p>
+<ul>
+  <li>
+    <em>Mesodinium rubrum</em> removed as evaluation showed the model was not reproducing the small number of observations available.
+  </li>
+  <li>
+    Functional light dependence was switched to a PE-curve style,
+    but tuned to closely match the <code>V19-05</code> response
+  </li>
+  <li>
+    Sinking for biological tracers was switched from upstream advection to being incorporated in the NEMO Flux-Corrected Transport scheme
+  </li>
+  <li>
+    River tracer inputs were updated
+  </li>
+  <li>
+    The N:O coupling for various processes was updated and a parameter for sediment oxygen
+    demand was added that effectively allows an oxygen flux into the sediments not coupled to an
+    outgoing nitrate flux.
+    It is proportional to the amount of organic matter sinking out of the domain.
+    Further improvements to oxygen in the model are ongoing.
+  </li>
+</ul>
+
+<h4>References</h4>
+<p>
+  Stang C. and Allen S.E., 2024.
+  Seasonably variable estuarine exchange through inter-connected channels in the Salish Sea.
+  ESS Open Archive, November 11, 2024.
+  DOI: <a href="https://doi.org/10.22541/essoar.173134323.35470755/v1">https://doi.org/10.22541/essoar.173134323.35470755/v1</a>
+</p>
+<p>
+  Morrison, J., Foreman, M. G. G., & Masson, D., 2012.
+  A Method for Estimating Monthly Freshwater Discharge Affecting British Columbia Coastal Waters. Atmosphere-Ocean, 50(1), 1–8.
+  <a href="https://doi.org/10.1080/07055900.2011.637667">https://doi.org/10.1080/07055900.2011.637667</a>
+</p>
+<p>
+  Moore-Maley, B. L., 2022.
+  Wind-driven upwelling and nutrient supply in a productive estuarine sea.
+  University of British Columbia.
+  <a href="https://open.library.ubc.ca/collections/ubctheses/24/items/1.0418447">https://open.library.ubc.ca/collections/ubctheses/24/items/1.0418447</a>
+</p>
+
+<h2>Citing SalishSeaCast Datasets</h2>
+<p>
+  If you use datasets from this ERDDAP™ server in your research,
+  please reference it with wording similar to these examples,
+  and include citations of the publications below.
+</p>
+<p>
+  Example reference for physics-only datasets:
+</p>
+<blockquote>
+  Velocity, temperature, and salinity fields from the SalishSeaCast model
+  (Soontiens et al, 2016; Soontiens and Allen, 2017) were downloaded from their ERDDAP™ server
+  (https://salishsea.eos.ubc.ca/erddap/) on <code>DATE</code> from datasets: <code>DATASETID</code>, <code>DATASETID</code>, ...
+</blockquote>
+<p>
+  Example reference for biological and dissolved oxygen datasets:
+</p>
+<blockquote>
+  Nitrate, silicon, and phytoplankton fields from the SalishSeaCast model
+  (Soontiens et al, 2016; Soontiens and Allen, 2017; Olson et al, 2020)
+  were downloaded from their ERDDAP™ server (https://salishsea.eos.ubc.ca/erddap/) on <code>DATE</code>
+  from datasets: <code>DATASETID</code>, <code>DATASETID</code>, ...
+</blockquote>
+<p>
+  Example reference for zooplankton datasets:
+</p>
+<blockquote>
+  Zooplankton fields from the SalishSeaCast model
+  (Soontiens et al, 2016; Soontiens and Allen, 2017; Olson et al, 2020; Suchy et al, 2023)
+  were downloaded from their ERDDAP™ server (https://salishsea.eos.ubc.ca/erddap/) on <code>DATE</code>
+  from datasets: <code>DATASETID</code>, <code>DATASETID</code>, ...
+</blockquote>
+<p>
+  Example reference for carbon chemistry datasets:
+</p>
+<blockquote>
+  Dissolved inorganic carbon, total alkalinity, and surface CO2 flux fields from the SalishSeaCast
+  model (Soontiens et al, 2016; Moore-Maley et al, 2016; Soontiens and Allen, 2017; Olson et al, 2020; Jarníková et al, 2022)
+  were downloaded from their ERDDAP™ server (https://salishsea.eos.ubc.ca/erddap/) on <code>DATE</code>
+  from datasets: <code>DATASETID</code>, <code>DATASETID</code>, ...
+</blockquote>
+<p>
+  In any of those cases,
+  you substitute in the <code>DATE</code>(s) on which you downloaded the fields,
+  and the <code>DATASETID</code>(s) you downloaded from.
+  The <code>DATE</code>(s) and <code>DATASETID</code>(s) help to ensure reproducibility of your work.
+  <code>DATASETID</code>(s) look like <code>ubcSSg3DTracerFields1hV21-11</code> and are listed in
+  the rightmost column of the table at
+  <a href="https://salishsea.eos.ubc.ca/erddap/info/index.html">https://salishsea.eos.ubc.ca/erddap/info/index.html</a>
+</p>
+
+<h3>Publications to Cite</h3>
+<p>
+  Suchy, K.D., Olson, E.M., Allen, S.E., Galbraith, M., Herrmann, B., Keister, J.E., Perry, R.I., Sastri, A.R., Young, K., 2023.
+  Seasonal and regional variability of model-based zooplankton biomass in the Salish Sea and evaluation against observations.
+  Progress in Oceanography, 219, 103171.
+  <a href="https://doi.org/10.1016/j.pocean.2023.103171">https://doi.org/10.1016/j.pocean.2023.103171</a>
+</p>
+<p>
+  Jarníková, T., Ianson, D., Allen, S.E., Shao, A.E., Olson, E.M., 2022.
+  Anthropogenic carbon increase has caused critical shifts in aragonite saturation across a sensitive coastal system.
+  Global Biogeochemical Cycles, 36(7).
+  <a href="https://doi.org/10.1029/2021GB007024">https://doi.org/10.1029/2021GB007024</a>
+</p>
+<p>
+  Olson, E. M., Allen, S. E., Do, Vy, Dunphy, M., and Ianson, D., 2020.
+  Assessment of Nutrient Supply by a Tidal Jet in the Northern Strait of Georgia Based on a Biogeochemical Model.
+  J. Geophys. Res. Oceans 125(8).
+  <a href="https://doi.org/10.1029/2019JC015766">https://doi.org/10.1029/2019JC015766</a>
+</p>
+<p>
+  Soontiens, N. and Allen, S., 2017.
+  Modelling sensitivities to mixing and advection in a sill-basin estuarine system.
+  Ocean Modelling, 112, 17-32.
+  <a href="https://dx.doi.org/10.1016/j.ocemod.2017.02.008">https://dx.doi.org/10.1016/j.ocemod.2017.02.008</a>
+</p>
+<p>
+  Soontiens, N., Allen, S., Latornell, D., Le Souef, K., Machuca, I., Paquin, J.-P., Lu, Y., Thompson, K., Korabel, V., 2016.
+  Storm surges in the Strait of Georgia simulated with a regional model.
+  Atmosphere-Ocean, 54, 1-21.
+  <a href="https://dx.doi.org/10.1080/07055900.2015.1108899">https://dx.doi.org/10.1080/07055900.2015.1108899</a>
+</p>
+<p>
+  Moore-Maley, B. L., Allen, S. E., and Ianson, D., 2016.
+  Locally-driven interannual variability of near-surface pH and ΩA in the Strait of Georgia.
+  J. Geophys. Res. Oceans, 121(3), 1600–1625.
+  <a href="https://dx.doi.org/10.1002/2015JC011118">https://dx.doi.org/10.1002/2015JC011118</a>
+</p>
+
+[standardShortDescriptionHtml]
+
+]]>
+</theShortDescriptionHtml>
+
+
 <dataset type="EDDGridFromNcFiles" datasetID="ubcSSnBathymetryV21-08" active="true">
   <reloadEveryNMinutes>10080</reloadEveryNMinutes>
   <updateEveryNMillis>10000</updateEveryNMillis>
-  <fileDir>/SalishSeaCast/grid/</fileDir>
+  <!-- <fileDir>/SalishSeaCast/grid/</fileDir> -->
+  <fileDir>/media/doug/warehouse/MEOPAR/grid/</fileDir>
   <recursive>false</recursive>
   <fileNameRegex>.*bathymetry_202108\.nc$</fileNameRegex>
   <metadataFrom>last</metadataFrom>
@@ -65,7 +364,6 @@ This product does not meet the requirements of Charts and Nautical Publications 
 1995 under the Canadian Shipping Act, 2001.
 Official charts and publications, corrected and up-to-data,
 must be used to meet the requirements of those regulations.</att>
-    <att name="drawLandMask">over</att>
     <att name="institution">UBC EOAS</att>
     <att name="institution_fullname">Dept of Earth, Ocean &amp; Atmospheric Sciences, University of British Columbia</att>
     <att name="infoUrl">https://salishsea.eos.ubc.ca/</att>
@@ -229,7 +527,8 @@ v21-08: same variables,
 <dataset type="EDDGridFromNcFiles" datasetID="ubcSSn2DMeshMaskV21-08" active="true">
   <reloadEveryNMinutes>10080</reloadEveryNMinutes>
   <updateEveryNMillis>10000</updateEveryNMillis>
-  <fileDir>/SalishSeaCast/grid/</fileDir>
+  <!-- <fileDir>/SalishSeaCast/grid/</fileDir> -->
+  <fileDir>/media/doug/warehouse/MEOPAR/grid/</fileDir>
   <recursive>false</recursive>
   <fileNameRegex>.*mesh_mask202108\.nc$</fileNameRegex>
   <metadataFrom>last</metadataFrom>

--- a/datasets.yaml
+++ b/datasets.yaml
@@ -8,7 +8,7 @@ postfix: postfix.xml
 # Dataset descriptions:
 datasets:
   # Bathymetry and NEMO mesh mask
-  # v221-08 bathymetry used for v2021-11 runs
+  # v21-08 bathymetry used for v2021-11 runs
   - nemo-grid/ubcSSnBathymetryV21-08.xml
   - nemo-grid/ubcSSn2DMeshMaskV21-08.xml
   - nemo-grid/ubcSSn3DMeshMaskV21-08.xml

--- a/datasets/prefix.xml
+++ b/datasets/prefix.xml
@@ -1,5 +1,30 @@
-<?xml version="1.0" encoding="ISO-8859-1" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <erddapDatasets>
+
+<!-- The tags below are described in setupDatasetsXml.html.
+      The defaults listed below are as of ERDDAP™ v2.00. -->
+<cacheMinutes>60</cacheMinutes>                                     <!-- default=60 -->
+<decompressedCacheMaxGB>10</decompressedCacheMaxGB>                 <!-- default=10 -->
+<decompressedCacheMaxMinutesOld>15</decompressedCacheMaxMinutesOld> <!-- default=15 -->
+<drawLandMask>over</drawLandMask>                                   <!-- "over" or "under" (default) -->
+<graphBackgroundColor></graphBackgroundColor>                       <!-- 0xAARRGGBB, default is 0xffccccff -->
+<loadDatasetsMinMinutes>15</loadDatasetsMinMinutes>                 <!-- usually=default=15 -->
+<loadDatasetsMaxMinutes>60</loadDatasetsMaxMinutes>                 <!-- default=60 -->
+<logLevel>info</logLevel>                                           <!-- "warning" (fewest messages), "info" (default), or "all" (most messages) -->
+<nGridThreads>1</nGridThreads>                                      <!-- default=1 -->
+<nTableThreads>1</nTableThreads>                                    <!-- default=1 -->
+<partialRequestMaxBytes>490000000</partialRequestMaxBytes>          <!-- default=490000000 -->
+<partialRequestMaxCells>10000000</partialRequestMaxCells>           <!-- default=10000000 -->
+<slowDownTroubleMillis>1000</slowDownTroubleMillis>                 <!-- default=1000 -->
+<unusualActivity>10000</unusualActivity>                            <!-- default=10000 -->
+<!-- The defaults for the following tags are in messages.xml. -->
+<standardLicense></standardLicense>
+<standardContact></standardContact>
+<standardDataLicenses></standardDataLicenses>
+<standardDisclaimerOfEndorsement></standardDisclaimerOfEndorsement>
+<standardDisclaimerOfExternalLinks></standardDisclaimerOfExternalLinks>
+<standardGeneralDisclaimer></standardGeneralDisclaimer>
+<standardPrivacyPolicy></standardPrivacyPolicy>
 
 <!-- If you want to refuse requests from certain clients
   (e.g., to fend off a Denial of Service attack or an overly zealous web robot),
@@ -10,7 +35,7 @@
 <requestBlacklist>
   <!-- dataforseo.com, an Estonian SEO company; swamped server with request failures on: -->
   <!-- 22sep23, 1apr24 -->
-  136.243.228.193,136.243.228.179
+  136.243.228.193, 136.243.228.179
 </requestBlacklist>
 
 <!-- If you want to prevent specific people from using the email/URL subscription
@@ -19,3 +44,278 @@
 -->
 <subscriptionEmailBlacklist>
 </subscriptionEmailBlacklist>
+
+<startHeadHtml5><![CDATA[
+<!DOCTYPE html>
+<html lang="en-US">
+<head>
+<meta charset="UTF-8">
+<title>SalishSeaCast ERDDAP™</title>
+<link rel="shortcut icon" href="&erddapUrl;/images/favicon.ico">
+<link href="&erddapUrl;/images/erddap2.css" rel="stylesheet" type="text/css">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+]]></startHeadHtml5>
+
+<startBodyHtml5><![CDATA[
+<body>
+<table class="compact nowrap" style="width:100%; background-color:#128CB5;">
+  <tr>
+    <td style="text-align:center; width:160px; padding-right: 20px;">
+      <a
+        rel="bookmark"
+        href="https://salishsea.eos.ubc.ca/">
+        <img
+          title="SalishSeaCast"
+          src="&erddapUrl;/images/UBC-MEOPAR-Logos.png" alt="UBC and MEOPAR Logos"
+          style="vertical-align:middle;"/>
+      </a>
+    </td>
+    <td style="text-align:left; font-size:x-large; color:#FFFFFF;">
+      <strong>SalishSeaCast ERDDAP™</strong>
+      <br><small><small><small>Public access to the SalishSeaCast model products</small></small></small>
+    </td>
+    <td style="text-align:right; font-size:small;">
+      &loginInfo; &nbsp; &nbsp;
+      <br>&BroughtToYouBy;
+      <a title="SalishSeaCast" rel="bookmark" href="https://salishsea.eos.ubc.ca/">SalishSeaCast</a>
+      <a title="UBC Earth, Ocean & Atmospheric Sciences" rel="bookmark" href="https://www.eoas.ubc.ca/">UBC EOAS</a>
+      <a title="Marine Environmental Observation Prediction and Response Network" rel="bookmark" href="http://meopar.ca/">MEOPAR</a>
+      <a title="National Oceanic and Atmospheric Administration" rel="bookmark" href="http://www.noaa.gov">NOAA</a>
+      &nbsp; &nbsp;
+    </td>
+  </tr>
+</table>
+]]></startBodyHtml5>
+
+<endBodyHtml5><![CDATA[
+<div class="standard_width">
+<br>&nbsp;
+<hr>
+ERDDAP™, Version &erddapVersion;
+<br><a rel="license" href="&erddapUrl;/legal.html">Disclaimers</a> |
+    <a rel="bookmark" href="&erddapUrl;/legal.html#privacyPolicy">Privacy Policy</a> |
+    <a rel="bookmark" href="&erddapUrl;/legal.html#contact">Contact</a>
+<p>&nbsp;
+<p>&nbsp;
+<p>&nbsp;
+<p>&nbsp;
+<p>&nbsp;
+<p>&nbsp;
+<p>&nbsp;
+<p>&nbsp;
+<p>&nbsp;
+<p>&nbsp;
+<p>&nbsp;
+</div>
+</body>
+]]></endBodyHtml5>
+
+<theShortDescriptionHtml><![CDATA[
+<h1>SalishSeaCast ERDDAP™</h1>
+<p>
+  ERDDAP™ is a data server that gives you a simple, consistent way to download
+  subsets of scientific datasets in common file formats and make graphs and maps.
+</p>
+<p>
+  This particular ERDDAP™ installation has model product datasets from the SalishSeaCast
+  system run by the Mesoscale Ocean and Atmospheric Dynamics (MOAD)
+  group in the Department of Earth, Ocean, and Atmospheric Sciences (EOAS)
+  at the University of British Columbia (UBC).
+  Available datasets include surface and 3D fields of currents, temperature, salinity,
+  sea surface height, biological and chemical tracers from NEMO and FVCOM,
+  and wave fields WaveWatch III®,
+  as well as the Environment and Climate Change Canada (ECCC)
+  High Resolution Deterministic Prediction System (HRDPS)
+  atmospheric model fields used to force the models.
+  Also available are aggregated datasets from selected Ocean Networks Canada (ONC) real-time sensors,
+  and a real-time current dataset from a Vancouver Fraser Port Authority (VFPA) sensor at the 2nd Narrows railway bridge in Vancouver Harbour.
+</p>
+<p>
+  Please see <a href="https://salishsea.eos.ubc.ca/">https://salishsea.eos.ubc.ca/</a>
+  for more information about the model and the SalishSeaCast system.
+</p>
+
+<h2>V21-11 NEMO Model is Live!</h2>
+<p>
+  A new, improved version of the SalishSeaCast NEMO model has been running in near-real-time since 1-Jan-2024.
+  A hindcast from 1-Jan-2007 using that model configuration was completed in late 2023.
+  New NEMO datasets from that model configuration were added to this ERDDAP™ starting in December 2023.
+  They are identified with a <code>V21-11</code> version string in their dataset ids, titles, summaries, etc.
+</p>
+<p>
+  The hindcast was spun up for 5 years with best available forcing and boundary conditions for 2002-2006.
+  The spin-up years are <em>not</em> included in the <code>V21-11</code> datasets.
+</p>
+<p>
+  The rolling forecast datasets are from the <code>V21-11</code> model configuration.
+  The version part of the rolling forecast dataset ids was dropped on 2-Jul-2019 to reflect the fact
+  that those datasets transition smoothly from one model version to the next.
+  Please see the summary metadata item to learn what model version is producing the most recent fields in the rolling forecast datasets.
+</p>
+
+<h3>Changes Between <code>V19-05</code> and <code>V21-11</code></h3>
+<h4>Physics</h4>
+<p>
+  From Stang and Allen, 2024:
+</p>
+<ul>
+  <li>
+    Daily river flows are calculated using continuous gauge records fitted to monthly watersheds
+    from Morrison et al. (2012), which allows for inter-annual variability like winter storms and summer droughts.
+  </li>
+  <li>
+    The bathymetry was improved by adjusting the coastline to the 2-m isobath
+    (previously set to the mean sea level isobath)
+    and then deepening the minimum water depth to 4 m.
+    These changes align the extent of the Fraser River plume more closely with observations.
+    The bathymetry is available in the
+    <a href="https://salishsea.eos.ubc.ca/erddap/info/ubcSSnBathymetryV21-08/index.html">ubcSSnBathymetryV21-08</a>
+    dataset.
+  </li>
+  <li>
+    Coastal wave characterization was improved using WaveWatch III® model results,
+    addressing the small fetch and waves in the Salish Sea (Moore-Maley, 2022).
+    The new parameterization reduces mixing by adjusting the turbulence parameterization surface boundary condition,
+    partially correcting the too salty surface salinities in the Fraser River plume.
+  </li>
+</ul>
+
+<h4>Biology</h4>
+<p>
+  From Suchy, et al, in preparation:
+</p>
+<ul>
+  <li>
+    <em>Mesodinium rubrum</em> removed as evaluation showed the model was not reproducing the small number of observations available.
+  </li>
+  <li>
+    Functional light dependence was switched to a PE-curve style,
+    but tuned to closely match the <code>V19-05</code> response
+  </li>
+  <li>
+    Sinking for biological tracers was switched from upstream advection to being incorporated in the NEMO Flux-Corrected Transport scheme
+  </li>
+  <li>
+    River tracer inputs were updated
+  </li>
+  <li>
+    The N:O coupling for various processes was updated and a parameter for sediment oxygen
+    demand was added that effectively allows an oxygen flux into the sediments not coupled to an
+    outgoing nitrate flux.
+    It is proportional to the amount of organic matter sinking out of the domain.
+    Further improvements to oxygen in the model are ongoing.
+  </li>
+</ul>
+
+<h4>References</h4>
+<p>
+  Stang C. and Allen S.E., 2024.
+  Seasonably variable estuarine exchange through inter-connected channels in the Salish Sea.
+  ESS Open Archive, November 11, 2024.
+  DOI: <a href="https://doi.org/10.22541/essoar.173134323.35470755/v1">https://doi.org/10.22541/essoar.173134323.35470755/v1</a>
+</p>
+<p>
+  Morrison, J., Foreman, M. G. G., & Masson, D., 2012.
+  A Method for Estimating Monthly Freshwater Discharge Affecting British Columbia Coastal Waters. Atmosphere-Ocean, 50(1), 1–8.
+  <a href="https://doi.org/10.1080/07055900.2011.637667">https://doi.org/10.1080/07055900.2011.637667</a>
+</p>
+<p>
+  Moore-Maley, B. L., 2022.
+  Wind-driven upwelling and nutrient supply in a productive estuarine sea.
+  University of British Columbia.
+  <a href="https://open.library.ubc.ca/collections/ubctheses/24/items/1.0418447">https://open.library.ubc.ca/collections/ubctheses/24/items/1.0418447</a>
+</p>
+
+<h2>Citing SalishSeaCast Datasets</h2>
+<p>
+  If you use datasets from this ERDDAP™ server in your research,
+  please reference it with wording similar to these examples,
+  and include citations of the publications below.
+</p>
+<p>
+  Example reference for physics-only datasets:
+</p>
+<blockquote>
+  Velocity, temperature, and salinity fields from the SalishSeaCast model
+  (Soontiens et al, 2016; Soontiens and Allen, 2017) were downloaded from their ERDDAP™ server
+  (https://salishsea.eos.ubc.ca/erddap/) on <code>DATE</code> from datasets: <code>DATASETID</code>, <code>DATASETID</code>, ...
+</blockquote>
+<p>
+  Example reference for biological and dissolved oxygen datasets:
+</p>
+<blockquote>
+  Nitrate, silicon, and phytoplankton fields from the SalishSeaCast model
+  (Soontiens et al, 2016; Soontiens and Allen, 2017; Olson et al, 2020)
+  were downloaded from their ERDDAP™ server (https://salishsea.eos.ubc.ca/erddap/) on <code>DATE</code>
+  from datasets: <code>DATASETID</code>, <code>DATASETID</code>, ...
+</blockquote>
+<p>
+  Example reference for zooplankton datasets:
+</p>
+<blockquote>
+  Zooplankton fields from the SalishSeaCast model
+  (Soontiens et al, 2016; Soontiens and Allen, 2017; Olson et al, 2020; Suchy et al, 2023)
+  were downloaded from their ERDDAP™ server (https://salishsea.eos.ubc.ca/erddap/) on <code>DATE</code>
+  from datasets: <code>DATASETID</code>, <code>DATASETID</code>, ...
+</blockquote>
+<p>
+  Example reference for carbon chemistry datasets:
+</p>
+<blockquote>
+  Dissolved inorganic carbon, total alkalinity, and surface CO2 flux fields from the SalishSeaCast
+  model (Soontiens et al, 2016; Moore-Maley et al, 2016; Soontiens and Allen, 2017; Olson et al, 2020; Jarníková et al, 2022)
+  were downloaded from their ERDDAP™ server (https://salishsea.eos.ubc.ca/erddap/) on <code>DATE</code>
+  from datasets: <code>DATASETID</code>, <code>DATASETID</code>, ...
+</blockquote>
+<p>
+  In any of those cases,
+  you substitute in the <code>DATE</code>(s) on which you downloaded the fields,
+  and the <code>DATASETID</code>(s) you downloaded from.
+  The <code>DATE</code>(s) and <code>DATASETID</code>(s) help to ensure reproducibility of your work.
+  <code>DATASETID</code>(s) look like <code>ubcSSg3DTracerFields1hV21-11</code> and are listed in
+  the rightmost column of the table at
+  <a href="https://salishsea.eos.ubc.ca/erddap/info/index.html">https://salishsea.eos.ubc.ca/erddap/info/index.html</a>
+</p>
+
+<h3>Publications to Cite</h3>
+<p>
+  Suchy, K.D., Olson, E.M., Allen, S.E., Galbraith, M., Herrmann, B., Keister, J.E., Perry, R.I., Sastri, A.R., Young, K., 2023.
+  Seasonal and regional variability of model-based zooplankton biomass in the Salish Sea and evaluation against observations.
+  Progress in Oceanography, 219, 103171.
+  <a href="https://doi.org/10.1016/j.pocean.2023.103171">https://doi.org/10.1016/j.pocean.2023.103171</a>
+</p>
+<p>
+  Jarníková, T., Ianson, D., Allen, S.E., Shao, A.E., Olson, E.M., 2022.
+  Anthropogenic carbon increase has caused critical shifts in aragonite saturation across a sensitive coastal system.
+  Global Biogeochemical Cycles, 36(7).
+  <a href="https://doi.org/10.1029/2021GB007024">https://doi.org/10.1029/2021GB007024</a>
+</p>
+<p>
+  Olson, E. M., Allen, S. E., Do, Vy, Dunphy, M., and Ianson, D., 2020.
+  Assessment of Nutrient Supply by a Tidal Jet in the Northern Strait of Georgia Based on a Biogeochemical Model.
+  J. Geophys. Res. Oceans 125(8).
+  <a href="https://doi.org/10.1029/2019JC015766">https://doi.org/10.1029/2019JC015766</a>
+</p>
+<p>
+  Soontiens, N. and Allen, S., 2017.
+  Modelling sensitivities to mixing and advection in a sill-basin estuarine system.
+  Ocean Modelling, 112, 17-32.
+  <a href="https://dx.doi.org/10.1016/j.ocemod.2017.02.008">https://dx.doi.org/10.1016/j.ocemod.2017.02.008</a>
+</p>
+<p>
+  Soontiens, N., Allen, S., Latornell, D., Le Souef, K., Machuca, I., Paquin, J.-P., Lu, Y., Thompson, K., Korabel, V., 2016.
+  Storm surges in the Strait of Georgia simulated with a regional model.
+  Atmosphere-Ocean, 54, 1-21.
+  <a href="https://dx.doi.org/10.1080/07055900.2015.1108899">https://dx.doi.org/10.1080/07055900.2015.1108899</a>
+</p>
+<p>
+  Moore-Maley, B. L., Allen, S. E., and Ianson, D., 2016.
+  Locally-driven interannual variability of near-surface pH and ΩA in the Strait of Georgia.
+  J. Geophys. Res. Oceans, 121(3), 1600–1625.
+  <a href="https://dx.doi.org/10.1002/2015JC011118">https://dx.doi.org/10.1002/2015JC011118</a>
+</p>
+
+[standardShortDescriptionHtml]
+
+]]>
+</theShortDescriptionHtml>

--- a/datasets/prefix.xml
+++ b/datasets/prefix.xml
@@ -47,7 +47,7 @@
 
 <startHeadHtml5><![CDATA[
 <!DOCTYPE html>
-<html lang="en-US">
+<html lang="&langCode;">
 <head>
 <meta charset="UTF-8">
 <title>SalishSeaCast ERDDAP™</title>

--- a/setenv.sh
+++ b/setenv.sh
@@ -1,4 +1,4 @@
-export JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64/
+export JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64
 export JAVA_OPTS='-server -Djava.awt.headless=true -Xmx64G -Xms64G'
 export TOMCAT_HOME=/opt/apache-tomcat-10.1.40
 export CATALINA_HOME=/opt/apache-tomcat-10.1.40

--- a/setenv.sh
+++ b/setenv.sh
@@ -1,0 +1,4 @@
+export JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64/
+export JAVA_OPTS='-server -Djava.awt.headless=true -Xmx64G -Xms64G'
+export TOMCAT_HOME=/opt/apache-tomcat-10.1.40
+export CATALINA_HOME=/opt/apache-tomcat-10.1.40

--- a/setup.xml
+++ b/setup.xml
@@ -1,23 +1,9 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!-- setup.xml contains setup information for ERDDAP.
 When you install ERDDAP on your server, many of the settings can be left as is.
-Settings that you must change when you install ERDDAP on your server are marked "MUST CHANGE".
+Settings that you MUST change are in this top section.
 -->
 <erddapSetup>
-
-<!-- 'logLevel' determines how many diagnostic messages are sent to the log.txt file.
-It can be set to "warning" (the fewest messages), "info" (the default), or "all" (the most messages).
-Diagnostic messages are always written to the [bigParentDirectory]/logs/log.txt file (see below).
-At ERD, we set this to 'all' for development and 'info' for releases.
--->
-<logLevel>info</logLevel>
-
-<!-- warName becomes part of the public url, after baseUrl/.
-This should always be 'erddap'.
-If you want to install a second ERDDAP for testing/development,
-see http://coastwatch.pfeg.noaa.gov/erddap/download/setup.html#secondErddap
--->
-<warName>erddap</warName>
 
 <!-- bigParentDirectory is the absolute path on the server (with slash at the end)
 to a directory on a drive with lots of space.
@@ -29,12 +15,42 @@ Subdirectories that will be created by ERDDAP are:
 * flag (where you can put a file with a datasetID's name to force reloading of
    that dataset) and
 * cache (which ERDDAP uses to hold cached data files - ERDDAP periodically
-   removes files older than cacheMinutes (see below)).
+   removes files older than cacheMinutes).
 The ERDDAP log file (log.txt) will be put in this directory.
-You MUST CHANGE this when you install ERDDAP on your server.
 At ERD, we use '/u00/cwatch/erddap/' for releases.
 -->
 <bigParentDirectory>/results/erddap/</bigParentDirectory>
+
+<!-- baseUrl is the start of the public url, to which "/erddap"
+is appended. For example:
+For running/testing on your personal computer:
+  <baseUrl>http://localhost:8080</baseUrl>
+  (127.0.0.1 doesn't work with authentication=google).
+For ERD releases, we use
+  <baseUrl>http://coastwatch.pfeg.noaa.gov</baseUrl>
+If you want to encourage all users to use https (not http),
+  make the baseUrl the same as the baseHttpsUrl (see below).
+-->
+<baseUrl>https://salishsea.eos.ubc.ca</baseUrl>
+
+<!-- This is a variant of <baseUrl> which is used when
+authentication is active and the user is logged in.
+In general, you take the <baseUrl>, change "http" to "https",
+and change/add ":8443". This must begin with "https://".
+If you make a proxy so that ":8443" isn't needed,
+then don't use ":8443" here.
+This is relevant even if <authentication> is "".
+See the instructions at
+https://coastwatch.pfeg.noaa.gov/erddap/download/setup.html#security
+For example:
+For running/testing on your personal computer:
+  <baseHttpsUrl>https://localhost:8443</baseHttpsUrl>
+For releases at ERD, we use:
+  <baseHttpsUrl>https://coastwatch.pfeg.noaa.gov</baseHttpsUrl>
+If you want to encourage all users to use https (not http),
+  make the baseUrl (see above) the same as the baseHttpsUrl.
+-->
+<baseHttpsUrl></baseHttpsUrl>
 
 <!-- Daily status reports and all error messages are emailed to emailEverythingTo.
 Daily status reports are emailed to emailDailyReportsTo.
@@ -44,110 +60,40 @@ Either of these can be not specified, blank (specified but with no value),
 The first emailEverythingTo email address is more important than the others,
   e.g., it is used for subscriptions to EDDXxxxFromErddap datasets.
 See the email account settings below.
-You MUST CHANGE these to the appropriate browser administrator for your site.
 
 Whether or not you set up the email system, all potential email messages
 are logged to an emailLogYEAR-MONTH.txt file in [bigParentDirectory]/logs/.
 -->
 <emailEverythingTo>dlatornell@eoas.ubc.ca</emailEverythingTo>
-<emailDailyReportsTo>dlatornell@eoas.ubc.ca</emailDailyReportsTo>
-
-<!-- This lets you specify a regular expression which determines which datasetIDs
-in the datasets.xml file should be loaded.
-The default is ".*", which loads all datasets.
-During development or for other reasons, you might want to use a subset, e.g.,
-"(etopo.*|erdQSu101day|erdMHchla8day|erdGlobecBottle|erdBAssta5day|pmelTaoDySst)",
-so that ERDDAP quickly loads a dataset that you are interested in.
--->
-<datasetsRegex>.*</datasetsRegex>
-
-<!-- If true, when you start up ERDDAP, some types of datasets (e.g.,
-EDDGridFromDap) will used cached information (.dds, .das, etc.) to reload
-very quickly, without contacting the remote server.  The dataset's age
-will be based on when the dataset was reloaded last.  Normally this
-should be true (the default), but set it to false if you want to bypass
-the cached information. -->
-<quickRestart>true</quickRestart>
-
-<!-- If you want to restrict access to some datasets, you need to specify
-the method used for logging on (authentication).
-See the info at http://coastwatch.pfeg.noaa.gov/erddap/download/setup.html#security
-Currently, the options are: "" (logins not supported, the default), "custom", "openid".
-Note that openid login doesn't work when testing with localhost (https://127.0.0.1:8443).
--->
-<authentication></authentication>
-
-<!-- This specifies how you have stored passwords in the roles tags in datasets.xml.
-If you aren't storing any passwords this is irrelevant.
-The options (in order of increasing security) are:
-"plaintext", "MD5", or "UEPMD5" (MD5(UserName:ERDDAP:Password) which is the default).
-You should only use "plaintext" or "MD5" if you need to match values stored
-that way in an external password database.
-See the info at http://coastwatch.pfeg.noaa.gov/erddap/download/setup.html#security
--->
-<passwordEncoding>UEPMD5</passwordEncoding>
-
-<!-- This determines whether datasets that the user doesn't currently have access to
-(because he isn't logged in or because his roles don't allow access)
-should be shown on lists of data sets
-(e.g., from full text search, categorize, view all datasets, ...).
-The options are: "true", or "false" (the default).
-If false, no information about the dataset (even its existence) is shown
-  to users who don't have access to it.
-If true, some information about the dataset (title, summary, etc) is shown
-  to users who don't have access to it.
-  If the user clicks on a link to a dataset he doesn't have access to,
-  he will get an error message and be prompted to log in.
--->
-<listPrivateDatasets>false</listPrivateDatasets>
-
-<!-- baseUrl is the start of the public url, to which "/[warName]" is appended.
-You MUST CHANGE this when you install ERDDAP on your server. For example,
-<baseUrl>http://127.0.0.1:8080</baseUrl>              used for running/testing on your personal computer
-<baseUrl>http://coastwatch.pfeg.noaa.gov</baseUrl>    used for ERD releases (erddap and erddap2)
+<!-- optional:
+<emailDailyReportsTo>your.boss@yourInstitution.edu</emailDailyReportsTo>
 -->
 
-<baseUrl>https://salishsea.eos.ubc.ca</baseUrl>
 
-<!-- This is a variant of <baseUrl> which is used when authentication is active and the user is logged in.
-  In general, you take the <baseUrl>, change "http" to "https", and change/add ":8443".
-  This must begin with "https://".
-  If you make a proxy so that ":8443" isn't needed, you don't need to add it here.
-  This is irrelevant if <authentication> is "".
-  See the instructions at http://coastwatch.pfeg.noaa.gov/erddap/download/setup.html#security
-  For example,
-<baseHttpsUrl>https://127.0.0.1:8443</baseHttpsUrl>                 used for running/testing on your personal computer
-<baseHttpsUrl>https://coastwatch.pfeg.noaa.gov:8443</baseHttpsUrl>  used at ERD for releases (erddap and erddap2)
--->
-<baseHttpsUrl></baseHttpsUrl>
+<!-- Email account information is used for sending emails to the
+'emailEverythingTo' and 'emailDailyReportsTo' email addresses above
+and for sending emails related to subscriptions. So if you don't setup the
+email system, your ERDDAP won't support subscriptions (including allowing other
+ERDDAP's to subscribe to datasets on your ERDDAP).
 
+If you don't want your ERDDAP to send emails, change the emailSmtpHost tag
+contents to be nothing.
 
-<!-- **************************************************************************** -->
-
-<!-- ERDDAP lets you choose between two search engines for full text searches:
-* original (the default) - is the best choice if your ERDDAP has fewer
-  than about 10,000 datasets.  It is very robust and trouble free.
-* lucene - is the best choice for more than about 10,000 datasets.
-  The advantages are that with any number of datasets it works fast
-  and uses very little memory.
-  But there are many things that might go wrong with individual
-  queries and with the whole system.
-  And although its behaviour (the datasets it finds and the order that
-  it ranks them) is almost identical to the original search engine,
-  it has a few quirky, subtle, small differences.
--->
-<searchEngine>original</searchEngine>
-
-<!-- Email account information is used for sending emails to the 'emailEverythingTo'
-and 'emailDailyReportsTo' email addresses above.
-You MUST CHANGE this information when you install ERDDAP on your server since you can't use Bob's account.
-If you don't actually want to send emails, change the emailSmtpHost tag contents to be nothing.
-
-emailPassword is optional; if absent, emails can't be sent to non-local addresses.
+It is a security risk to put your email password in a plain text file like this.
+To mitigate that problem, we strongly recommend that you:
+1) Set up an email account just for ERDDAP's use, e.g.,
+   erddap@yourInstitution.org
+   That has other benefits as well: more than one ERDDAP administrator can then
+   be given access to that email account.
+2) Make the permissions of this setup.xml file rw (read+write) for the user who
+   will run Tomcat and ERDDAP (user=tomcat?) and no permissions (not read or
+   write) for the group and other users.
 
 emailProperties is a list of additional properties in the form
   prop1|value1|prop2|value2
 The default is nothing.
+
+If possible, set this up to use a secure connection (SSL / TLS) to the email server.
 
 For gmail (even your.name@noaa.gov accounts which are managed by Google),
   for emailSmtpHost, use smtp.gmail.com
@@ -171,9 +117,8 @@ Prevent mass mailing worms from sending mail" is un-checked.
 <!-- <emailSmtpPort>587</emailSmtpPort> -->
 
 
-<!-- Information about the ERDDAP administrator is used for the SOS and WMS servers.
-You MUST CHANGE these to describe your installation.
--->
+<!-- Information about the ERDDAP administrator is used for the SOS and WMS
+servers. -->
 <adminInstitution>EOAS UBC</adminInstitution>
 <adminInstitutionUrl>https://www.eoas.ubc.ca</adminInstitutionUrl>
 <adminIndividualName>Doug Latornell</adminIndividualName>
@@ -186,6 +131,146 @@ You MUST CHANGE these to describe your installation.
 <adminCountry>Canada</adminCountry>
 <adminEmail>dlatornell@eoas.ubc.ca</adminEmail>
 
+
+<!-- Normally, if you have a EDDGridFromErddap or EDDTableFromErddap
+dataset in your datasets.xml, it will try to subscribe to the remote
+ERDDAP dataset so that the local dataset is kept perfectly up-to-date.
+If this ERDDAP is not publicly accessible (http://localhost), or its
+IP address will change soon, or you have some other reason,
+you can tell this ERDDAP to not try to subscribe to the remote
+ERDDAP datasets by setting this to false. (default=true)
+This is the overall setting for this ERDDAP. It can be overridden by
+the same tag (with a different value) in the datasets.xml chunk for
+a given EDD...FromErddap dataset.
+For each fromErddap dataset that doesn't subscribe to the remote
+ERDDAP dataset, you should set <reloadEveryNMinutes> to a smaller
+number so that the local dataset stays reasonably up-to-date. -->
+<subscribeToRemoteErddapDataset>true</subscribeToRemoteErddapDataset>
+
+<!-- The font family to be used for all of the text in images.
+See the fontFamily documentation on the ERDDAP setup.html#fonts web page. -->
+<fontFamily>DejaVu Sans</fontFamily>
+
+<!-- ERDDAP has a service that lets remote users set a flag
+to notify ERDDAP to try to reload a dataset.
+These requests use a key which is generated based
+on baseUrl/erddap, a datasetID, and flagKeyKey.
+*** CHANGE THIS ONCE, to any text (a favorite quote? random text? Whatever you want.).
+Normally, you won't ever change this again.
+But if you you think someone is abusing the flag system,
+change this text again, restart ERDDAP, and send
+all of the users of the flag system the relevant new flagKeys
+(see the list in the Daily Report). -->
+<flagKeyKey>Automatic Fail</flagKeyKey>
+
+
+<!-- ******** End of MUST change settings.  ******************************** -->
+
+
+<!-- The default log file maximum size is 20 MB. When that size is reached,
+log.txt will be renamed to log.txt.previous .
+Minimum allowed is 1. Maximum allowed is 2000. -->
+<logMaxSizeMB>20</logMaxSizeMB>
+
+<!-- This lets you specify a regular expression which determines which datasetIDs
+in the datasets.xml file should be loaded.
+The default is ".*", which loads all datasets.
+During development or for other reasons, you might want to use a subset, e.g.,
+"(etopo.*|erdQSu101day|erdMHchla8day|erdGlobecBottle|erdBAssta5day|pmelTaoDySst)",
+so that ERDDAP quickly loads a dataset that you are interested in.
+-->
+<datasetsRegex>.*</datasetsRegex>
+
+<!-- If true, when you start up ERDDAP, some types of datasets (e.g.,
+EDDGridFromDap) will used cached information (.dds, .das, etc.) to reload
+very quickly, without contacting the remote server.  The dataset's age
+will be based on when the dataset was reloaded last.  Normally this
+should be true (the default), but set it to false if you want to bypass
+the cached information. -->
+<quickRestart>true</quickRestart>
+
+<!-- If you want to restrict access to some datasets,
+you need to specify the method used for logging on (authentication).
+See the info at
+https://coastwatch.pfeg.noaa.gov/erddap/download/setup.html#security
+Currently, the options are: "" (logins not supported, the default),
+"custom" (discouraged), "email" (discouraged), "google" (recommended),
+"orcid" (recommended), and "oauth2" (recommended).
+[No longer supported: "basic", "openid"]
+-->
+<authentication></authentication>
+
+<!-- If authentication=google, you must supply your Google Client ID.
+See
+https://developers.google.com/identity/sign-in/web/devconsole-project
+When setting this up, for Authorized JavaScript origins,
+for testing on your computer, use the domain "localhost"
+(e.g., origin=https://localhost:8443),
+not "127.0.0.1" (because Google Sign-In doesn't work with anything
+at that domain).
+This will be a string of about 75 characters, probably starting with
+several digits and ending with .apps.googleusercontent.com .
+-->
+<googleClientID></googleClientID>
+
+<!-- If authentication=orcid or oauth2, you must supply your ORCID APP Client ID
+  (which will start with "APP-") and ORCID Client Secret (a hex number with hyphens).
+  Get these by logging into Orcid at https://orcid.org/signin.
+  Then click on "Developer Tools" (under "For Researchers" at the top).
+  Then click on "Register for the free ORCID public API".
+    Name: ERDDAP at [your organization]
+    Website: [your ERDDAP's domain]
+    Description: ERDDAP is a scientific data server. Users need to authenticate with Google or Orcid to access non-public datasets.
+    Redirect URIs: [your ERDDAP's domain]/erddap/loginOrcid.html
+  Then click on the Save icon (looks like a 3.5" disk!).
+    -->
+<orcidClientID></orcidClientID>
+<orcidClientSecret></orcidClientSecret>
+
+<!-- For "custom" authentication, this specifies how you have
+stored passwords in the roles tags in datasets.xml.
+If you aren't storing any passwords, this is irrelevant.
+The options (in order of increasing security) are:
+"MD5", "UEPMD5" (MD5(UserName:ERDDAP:Password)),
+"SHA256", "UEPSHA256" (SHA256(UserName:ERDDAP:Password),
+the default).
+You should only use "MD5" or "SHA256" if you need to match
+values stored that way in an external password database.
+See the info at
+https://coastwatch.pfeg.noaa.gov/erddap/download/setup.html#security
+-->
+<passwordEncoding>UEPSHA256</passwordEncoding>
+
+<!-- This determines whether datasets that the user doesn't currently have access
+to (because he isn't logged in or because his roles don't allow access)
+should be shown on lists of data sets
+(e.g., from full text search, categorize, view all datasets, ...).
+The options are: "true", or "false" (the default).
+If false, no information about the dataset (even its existence) is shown
+  to users who don't have access to it.
+If true, some information about the dataset (title, summary, etc) is shown
+  to users who don't have access to it.
+  If the user clicks on a link to a dataset he doesn't have access to,
+  he will get an error message and be prompted to log in.
+-->
+<listPrivateDatasets>false</listPrivateDatasets>
+
+
+<!-- ERDDAP lets you choose between two search engines for full text searches:
+* original (the default) - is the best choice in almost all cases.
+  It is very robust, trouble-free, and gives the results users expect.
+* lucene - is an option if you have >10,000 datasets and find 'original' to be too slow;
+  otherwise, 'original' is strongly preferred.
+  The advantages are that with any number of datasets it works fast
+  and uses very little memory.
+  But there are many things that might go wrong with individual
+  queries and with the whole system.
+  And although its behaviour (the datasets it finds and the order that
+  it ranks them) is almost identical to the original search engine,
+  it has a few quirky, subtle, small, disadvantageous differences.
+-->
+<searchEngine>original</searchEngine>
+
 <!--
 These default accessConstraints, fees, and keywords are used by
   ERDDAP's SOS, WCS, and WMS services.
@@ -193,7 +278,8 @@ accessConstraints and fees are the defaults for dataset's without an
   "accessibleTo" tag.
 accessRequiresAuthorization is the default "accessConstraints" for dataset's
   with an "accessibleTo" tag.
-keywords should describe this ERDDAP's data in a general way and be comma-separated.
+keywords should describe this ERDDAP's data in a general way and be
+comma-separated.
 "accessConstraints", "fees", "keywords" can be overwritten by same-named
   attributes in a dataset's global attributes in datasets.xml.
 -->
@@ -201,17 +287,6 @@ keywords should describe this ERDDAP's data in a general way and be comma-separa
 <accessRequiresAuthorization>only accessible to authorized users</accessRequiresAuthorization>
 <fees>NONE</fees>
 <keywords>earth science, atmosphere, ocean, biosphere, biology, environment</keywords>
-
-<!-- This appears on the erddap/legal.html web page after the General Disclaimer.
-You can replace any of the [standardParts] with your own HTML.
-[standardContact] references the adminEmail specified above. -->
-<legal><![CDATA[
-[standardDisclaimerOfEndorsement]
-[standardDisclaimerOfExternalLinks]
-[standardPrivacyPolicy]
-[standardDataLicenses]
-[standardContact]
-]]></legal>
 
 <!-- Specify the default units standard (e.g., "UDUNITS" (the default) or "UCUM")
   that you (the ERDDAP admin) are using to specify units.
@@ -229,36 +304,15 @@ By default these services are on (true). -->
 
 <!-- The default for filesActive is "true". -->
 <filesActive>true</filesActive>
+<!-- This sets the default <accessibleViaFiles> for all of the datasets.
+     Before ERDDAP v.2.10, this tag didn't exist and the hard-coded setting was 'false'. -->
+<defaultAccessibleViaFiles>false</defaultAccessibleViaFiles>
 
 <!-- The default for dataProviderFormActive is "true". -->
 <dataProviderFormActive>true</dataProviderFormActive>
 
-<!-- For the wms examples, pick one of your grid datasets that has longitude and latitude axes.
-The sample variable must be a variable in the sample grid dataset.
-The bounding box values are minx,miny,maxx,maxy.
-The default for wmsActive is "true".
--->
-<wmsActive>true</wmsActive>
-<wmsSampleDatasetID>jplMURSST</wmsSampleDatasetID>
-<wmsSampleVariable>analysed_sst</wmsSampleVariable>
-<!-- The bounding box values are minLongitude,minLatitude,maxLongitude,maxLatitude.
-   Longitude values within -180 to 180, or 0 to 360, are now okay. -->
-<wmsSampleBBox>-179.995,-89.9945,179.995,89.9945</wmsSampleBBox>
-
-<!-- ERDDAP has a service that lets remote users set a flag
-to notify ERDDAP to try to reload a dataset.
-These requests use a key which is generated based
-on baseUrl/warName, a datasetID, and flagKeyKey.
-*** CHANGE THIS ONCE, to any text (a favorite quote? random text? It doesn't matter).
-Normally, you won't ever change this again.
-But if you you think someone is abusing the flag system,
-change this text again, restart ERDDAP, and send
-all of the users of the flag system the relevant new flagKeys
-(see the list in the Daily Report). -->
-<flagKeyKey>Automatic Fail</flagKeyKey>
-
 <!-- ERDDAP has an email/URL subscription system which sends a user an email
-or pings a url whenever an interesting dataset changes.
+or pings a URL whenever an interesting dataset changes.
 (This is different from the RSS system, which is always active.)
 The system relies on the server being able to send out
 emails to people to validate their subscription requests.
@@ -286,124 +340,33 @@ You may make this system active ("true", the default value) or not ("false").
 
 
 
-<!-- Every loadDatasetsNMinutes (see below), files in [bigParentDirectory]/cache/ and
-the public directory which are more than cacheMinutes old will be deleted.
-At ERD, we use '60'.
-Note that when a dataset is reloaded, all files in the [bigParentDirectory]/cache/[datasetID]
-directory are deleted.
-In general, only image files are cached, because the same images are often requested repeatedly.
-Removing files in the cache based on age (not Least-Recently-Used)
-ensures that files won't stay in the cache very long.
-Although it might seem like a given request should always return the same response,
-that isn't true.
-For example, a tabledap request which includes time>someTime will change
-if new data arrives for the dataset.
-And a griddap request which includes [last] for the time dimension will change
-if new data arrives for the dataset.
--->
-<cacheMinutes>60</cacheMinutes>
-
-<!-- This specifies the fewest minutes between checks if the datasets
-need to be reloaded.
-If a given run of loadDatasets takes less than this time,
-the loader just looks at the flag directory and/or sleeps
-until the remaining time has passed.
-The default is 15 minutes, which should be fine for almost everyone.
-No matter what, each dataset won't be reloaded more often than its
-reloadEveryNMinutes value as specified in datasets.xml.
-
-The only disadvantage to setting this to a smaller number is that
-it will increase the frequency that ERDDAP retries datasets that aren't
-loading. If there are lots of such datasets and they are retested frequently,
-the data source might consider it pestering/aggressive behaviour.
--->
-<loadDatasetsMinMinutes>15</loadDatasetsMinMinutes>
-
-<!-- This specifies the most minutes that reloading datasets is allowed to take
-(before the loadDatasets thread treated as "stalled" and is interrupted).
-In general, this should be set to at least twice as long as you reasonably
-think that reloading all of the datasets (cumulatively) should take
-(since computers and networks sometimes are slower than expected)
-This should always be much longer than loadDatasetsMinMinutes.
-The default is 60 minutes.  Some people will set this to longer.
--->
-<loadDatasetsMaxMinutes>60</loadDatasetsMaxMinutes>
-
-<!-- If the number of requests between two runs of LoadDatasets exceeds
-unusualActivity, an email is sent to emailEverythingTo.
-The default is 10000.
--->
-<unusualActivity>10000</unusualActivity>
-
-<!-- This is used to specify the directory with the unit test data files.
+<!-- This is used to specify the directories with the unit test data files.
      Only people that are running the ERDDAP unit tests need to specify this.
 <unitTestDataDir>/someDirectory/</unitTestDataDir>
+<unitTestBigDataDir>/someBigDirectory/</unitTestBigDataDir>
 -->
 
-<!-- The title for the map's legend (or nothing if you don't want a legend title).
-At ERD, we don't use these.  To use these, uncomment them.
-<legendTitle1>NOAA ERD's</legendTitle1>
-<legendTitle2>ERDDAP</legendTitle2>
--->
 
 <!-- The highRes and lowResImagefiles are used for map and graph legends
-(if legendTitle1 and legendTitle2 aren't "") and
-are scaled to the desired size (highRes->80 or 40 pixels square, lowRes->20 pixels square).
+and are scaled to the desired size (highRes->80 or 40 pixels square,
+lowRes->20 pixels square).
 The googleEarthLogoFile is displayed at its original size in the lower left
 corner of the Google Earth map if the user selects the .kml image file type.
 The highRes, lowRes and GoogleEarth images are also used by OpenSearch.
-The questionMarkImage identifies the places on HTML pages where a user can
-mouseOver to get more information.
 These files must be in [tomcat]/content/erddap/images/ directory.
 All files in this directory (and subdirectories)
 will be copied to [tomcat]/webapps/erddap/images (and subdirectories)
 and thus made available for direct downloading by any client.
 (Any text files must be stored as plain ASCII (7 bit) or with UTF-8 encoding.)
-For SGT graphics, currently, the Files designated below must be png, gif, jpg, or bmp.
+For SGT graphics, currently, the Files designated below must be png, gif, jpg,
+or bmp.
 If you want to substitute other image files, it is best to make them
 a similar number of pixels wide and high.
 -->
 <highResLogoImageFile>noaa_simple.gif</highResLogoImageFile>
 <lowResLogoImageFile>noaa20.gif</lowResLogoImageFile>
 <googleEarthLogoFile>nlogo.gif</googleEarthLogoFile>
-<questionMarkImageFile>QuestionMark.jpg</questionMarkImageFile>
 
-<!-- Normally, if you have a EDDGridFromErddap or EDDTableFromErddap
-dataset in your datasets.xml, it will try to subscribe to the remote
-ERDDAP dataset so that the local dataset is kept perfectly up-to-date.
-If this ERDDAP is not publicly accessible (http://localhost), or its
-IP address will change soon, or you have some other reason,
-you can tell this ERDDAP to not try to subscribe to the remote
-ERDDAP datasets by setting this to false. (default=true)
-This is the overall setting for this ERDDAP. It can be overridden by
-the same tag (with a different value) in the datasets.xml chunk for
-a given EDD...FromErddap dataset.
-For each fromErddap dataset that doesn't subscribe to the remote
-ERDDAP dataset, you should set <reloadEveryNMinutes> to a smaller
-number so that the local dataset stays reasonably up-to-date. -->
-<subscribeToRemoteErddapDataset>false</subscribeToRemoteErddapDataset>
-
-<!-- The font family to be used for all of the text in images.
-"SansSerif" (the default) is always a valid and reasonable option.
-A list of valid font families is printed to the log by the SGT constructor.
-SansSerif is fine on Windows.  I think it translates to Arial.
-I didn't like any of the fonts initially available on Linux. "SansSerif" is almost ok.
-At ERD, we use "Bitstream Vera Sans"
-  (open source fonts from http://www.gnome.org/fonts/ ).
-  I think they are distinctly better than the standard Linux fonts.
-  To use them on your computer, download
-  http://coastwatch.pfeg.noaa.gov/erddap/download/BitstreamVeraSans.zip
-  and unzip the files into [javaHome]/jre/lib/fonts so Java sees them.
--->
-<!-- <fontFamily>Bitstream Vera Sans</fontFamily> -->
-<fontFamily>DejaVu Sans</fontFamily>
-
-<!-- When possible (and it isn't always possible), ERDDAP breaks source data requests
-into chunks to conserve memory. See the description of these tags in messages.xml.
-You can override the default chunk sizes here with
-  For grids:  <partialRequestMaxBytes>100000000</partialRequestMaxBytes>
-  For tables: <partialRequestMaxCells>100000</partialRequestMaxCells>
--->
 
 <!-- If variablesRequireIoosCategory is true, all variables for all datasets must
 have an "ioos_category" attribute defined (in sourceAttributes or addAttributes)
@@ -417,366 +380,17 @@ For non-NOAA ERDDAP installations, there is no downside to setting this to "fals
 
 <!-- This is the comma-separated list (recommended: in alphabetical order)
 of the global attribute and variable attribute names which will be
-used to categorize the datasets and shown to clients at urls like .../erddap/categorize/ioos_category/index.html
+used to categorize the datasets and shown to clients at urls like
+.../erddap/categorize/ioos_category/index.html
 (ioos_category is unusual, but is used at ERD).
 If an attribute is a global attribute, identify it by prefixing it with "global:".
 "variableName" is a special case: it categorizes the dataVariable destinationNames.
 -->
 <categoryAttributes>global:cdm_data_type, global:institution, ioos_category, global:keywords, long_name, standard_name, variableName</categoryAttributes>
 
-
-
-<!-- drawLandMask specifies the default Make A Graph setting for whether the
-landmask should be drawn "over" or "under" surface data on maps.
-"over" is recommended for primarily oceanographic data
-(so that grid data over land is obscured by the landmask).
-"under" is the default and is suitable for all data.
--->
-<drawLandMask>under</drawLandMask>
-
-
-
-
-<!-- startHeadHtml has the start of the HTML document and the 'head' tags
-(starting at "<!DOCTYPE>", but not including "</head>")
-for all HTML web pages.
-This may include &erddapUrl;, which is expanded to be [baseUrl]/erddap
-  (or [baseUttpsUrl]/erddap if the user is logged in).
-If your ERDDAP allows users to log in, all referenced image files, css files,
-  etc. must be in [tomcat]/content/erddap/images or a subdirectory
-  and must be referenced here with &erddapUrl;/images/[fileName].
-
-favicon.ico is the image that browsers associate with your website.
-More more information, see http://en.wikipedia.org/wiki/Favicon .
-You can use your own favicon.ico file by putting it in (tomcat)/content/erddap/images.
-
-*** Optional: you can change the appearance of all of your
-ERDDAP's HTML pages by changing the CSS <style> settings below.
-
-For an example of a very different style, change the import reference to
-  [tomcat]/content/erddap/images/erddapAlt.css
-
-*** If your CSS style includes links to files (e.g., images), that style
-information must be inline in the style tag below, after the 'import' line,
-not in the .css file.
-Put all of the (e.g., image) files in the [tomcat]/content/erddap/images
-directory (or a subdirectory) and reference them below starting with
-&erddapUrl;.
-Why? On ERDDAP https: web pages, *all* links should use https: (not http:);
-otherwise, most browsers consider the web page not fully secure.
-Because ERDDAP would use the same .css file for http: and https: web pages,
-the links within the .css file wouldn't switch between http: and https:.
-There doesn't seem to be a way around this other than using inline style
-information.
--->
-<startHeadHtml5><![CDATA[
-<!DOCTYPE html>
-<html lang="en-US">
-<head>
-<meta charset="UTF-8">
-<title>SalishSeaCast ERDDAP</title>
-<link rel="shortcut icon" href="&erddapUrl;/images/favicon.ico">
-<link href="&erddapUrl;/images/erddap2.css" rel="stylesheet" type="text/css">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-]]></startHeadHtml5>
-
-<!-- This is the start of the body of the HTML code for all HTML web pages (starting with the 'body' tag).
-This may include &erddapUrl;, which is expanded to be [baseUrl]/erddap
-  (or [baseUttpsUrl]/erddap if the user is logged in).
-If your ERDDAP allows users to log in, all referenced image files, etc.
-  must be in [tomcat]/content/erddap/images or a subdirectory
-  and must be referenced here with &erddapUrl;/images/[fileName].
-To use https: and have users log in, see all the instructions at
-  http://coastwatch.pfeg.noaa.gov/erddap/download/setup.html#security
-  and include "&loginInfo;" in startBodyHtml to include the user's login status
-  (and a link to log in/out).
-  If authentication="", &loginInfo; disappears.
--->
-<startBodyHtml5><![CDATA[
-<body>
-<table class="compact nowrap" style="width:100%; background-color:#128CB5;">
-  <tr>
-    <td style="text-align:center; width:160px; padding-right: 20px;">
-      <a
-        rel="bookmark"
-        href="https://salishsea.eos.ubc.ca/">
-        <img
-          title="SalishSeaCast"
-          src="&erddapUrl;/images/UBC-MEOPAR-Logos.png" alt="UBC and MEOPAR Logos"
-          style="vertical-align:middle;"/>
-      </a>
-    </td>
-    <td style="text-align:left; font-size:x-large; color:#FFFFFF;">
-      <strong>SalishSeaCast ERDDAP</strong>
-      <br><small><small><small>Public access to the SalishSeaCast model products</small></small></small>
-    </td>
-    <td style="text-align:right; font-size:small;">
-      &loginInfo; &nbsp; &nbsp;
-      <br>Brought to you by
-      <a title="SalishSeaCast" rel="bookmark" href="https://salishsea.eos.ubc.ca/">SalishSeaCast</a>
-      <a title="UBC Earth, Ocean & Atmospheric Sciences" rel="bookmark" href="https://www.eoas.ubc.ca/">UBC EOAS</a>
-      <a title="Marine Environmental Observation Prediction and Response Network" rel="bookmark" href="http://meopar.ca/">MEOPAR</a>
-      <a title="National Oceanic and Atmospheric Administration" rel="bookmark" href="http://www.noaa.gov">NOAA</a>
-      &nbsp; &nbsp;
-    </td>
-  </tr>
-</table>
-]]></startBodyHtml5>
-
-<!-- The end of the body of the HTML code for all HTML web pages (with "</body>" at the end).
-This may include &erddapUrl;, which is expanded to be [baseUrl]/erddap
-  (or [baseUttpsUrl]/erddap if the user is logged in).
-If your ERDDAP allows users to log in, all referenced image files, etc.
-  must be in [tomcat]/content/erddap/images or a subdirectory
-  and must be referenced here with &erddapUrl;/images/[fileName].
-
-Please change the email address below.
-You can change other things, but please keep "ERDDAP, Version &erddapVersion;" and
-these references to the Disclaimers and Privacy Policy. -->
-<endBodyHtml5><![CDATA[
-<div class="standard_width">
-<br>&nbsp;
-<hr>
-ERDDAP, Version &erddapVersion;
-<br><a rel="license" href="&erddapUrl;/legal.html">Disclaimers</a> |
-    <a rel="bookmark" href="&erddapUrl;/legal.html#privacyPolicy">Privacy Policy</a> |
-    <a rel="bookmark" href="&erddapUrl;/legal.html#contact">Contact</a>
-<p>&nbsp;
-<p>&nbsp;
-<p>&nbsp;
-<p>&nbsp;
-<p>&nbsp;
-<p>&nbsp;
-<p>&nbsp;
-<p>&nbsp;
-<p>&nbsp;
-<p>&nbsp;
-<p>&nbsp;
-</div>
-</body>
-]]></endBodyHtml5>
-
-
-<!-- This is the short description of ERDDAP, which is used on the middle of the
-left side of ERDDAP's home page.
-This can refer to &erddapUrl;, &requestFormatExamplesHtml; &resultsFormatExamplesHtml; and
-[standardShortDescriptionHtml] (from messages.xml).
-If your ERDDAP allows users to log in, all referenced image files, etc.
-  must be in [tomcat]/content/erddap/images or a subdirectory
-  and must be referenced here with &erddapUrl;/images/[fileName].
-If you don't use [standardShortDescriptionHtml], at least include a link like:
-(<a href="&erddapUrl;/information.html">More detailed information about ERDDAP</a>)
-All of the information in [standardShortDescriptionHtml] is also contained in
-<theLongDescriptionHtml> in messages.xml.
--->
-<theShortDescriptionHtml><![CDATA[
-<h1>SalishSeaCast ERDDAP</h1>
-<p>
-  ERDDAP is a data server that gives you a simple, consistent way to download
-  subsets of scientific datasets in common file formats and make graphs and maps.
-</p>
-<p>
-  This particular ERDDAP installation has model product datasets from the SalishSeaCast
-  system run by the Mesoscale Ocean and Atmospheric Dynamics (MOAD)
-  group in the Department of Earth, Ocean, and Atmospheric Sciences (EOAS)
-  at the University of British Columbia (UBC).
-  Available datasets include surface and 3D fields of currents, temperature, salinity,
-  sea surface height, biological and chemical tracers from NEMO and FVCOM,
-  and wave fields WaveWatch III®,
-  as well as the Environment and Climate Change Canada (ECCC)
-  High Resolution Deterministic Prediction System (HRDPS)
-  atmospheric model fields used to force the models.
-  Also available are aggregated datasets from selected Ocean Networks Canada (ONC) real-time sensors,
-  and a real-time current dataset from a Vancouver Fraser Port Authority (VFPA) sensor at the 2nd Narrows railway bridge in Vancouver Harbour.
-</p>
-<p>
-  Please see <a href="https://salishsea.eos.ubc.ca/">https://salishsea.eos.ubc.ca/</a>
-  for more information about the model and the SalishSeaCast system.
-</p>
-
-<h2>V21-11 NEMO Model is Live!</h2>
-<p>
-  A new, improved version of the SalishSeaCast NEMO model has been running in near-real-time since 1-Jan-2024.
-  A hindcast from 1-Jan-2007 using that model configuration was completed in late 2023.
-  New NEMO datasets from that model configuration were added to this ERDDAP starting in December 2023.
-  They are identified with a <code>V21-11</code> version string in their dataset ids, titles, summaries, etc.
-</p>
-<p>
-  The hindcast was spun up for 5 years with best available forcing and boundary conditions for 2002-2006.
-  The spin-up years are <em>not</em> included in the <code>V21-11</code> datasets.
-</p>
-<p>
-  The rolling forecast datasets are from the <code>V21-11</code> model configuration.
-  The version part of the rolling forecast dataset ids was dropped on 2-Jul-2019 to reflect the fact
-  that those datasets transition smoothly from one model version to the next.
-  Please see the summary metadata item to learn what model version is producing the most recent fields in the rolling forecast datasets.
-</p>
-
-<h3>Changes Between <code>V19-05</code> and <code>V21-11</code></h3>
-<h4>Physics</h4>
-<p>
-  From Stang and Allen, 2024:
-</p>
-<ul>
-  <li>
-    Daily river flows are calculated using continuous gauge records fitted to monthly watersheds
-    from Morrison et al. (2012), which allows for inter-annual variability like winter storms and summer droughts.
-  </li>
-  <li>
-    The bathymetry was improved by adjusting the coastline to the 2-m isobath
-    (previously set to the mean sea level isobath)
-    and then deepening the minimum water depth to 4 m.
-    These changes align the extent of the Fraser River plume more closely with observations.
-    The bathymetry is available in the
-    <a href="https://salishsea.eos.ubc.ca/erddap/info/ubcSSnBathymetryV21-08/index.html">ubcSSnBathymetryV21-08</a>
-    dataset.
-  </li>
-  <li>
-    Coastal wave characterization was improved using WaveWatch III® model results,
-    addressing the small fetch and waves in the Salish Sea (Moore-Maley, 2022).
-    The new parameterization reduces mixing by adjusting the turbulence parameterization surface boundary condition,
-    partially correcting the too salty surface salinities in the Fraser River plume.
-  </li>
-</ul>
-
-<h4>Biology</h4>
-<p>
-  From Suchy, et al, in preparation:
-</p>
-<ul>
-  <li>
-    <em>Mesodinium rubrum</em> removed as evaluation showed the model was not reproducing the small number of observations available.
-  </li>
-  <li>
-    Functional light dependence was switched to a PE-curve style,
-    but tuned to closely match the <code>V19-05</code> response
-  </li>
-  <li>
-    Sinking for biological tracers was switched from upstream advection to being incorporated in the NEMO Flux-Corrected Transport scheme
-  </li>
-  <li>
-    River tracer inputs were updated
-  </li>
-  <li>
-    The N:O coupling for various processes was updated and a parameter for sediment oxygen
-    demand was added that effectively allows an oxygen flux into the sediments not coupled to an
-    outgoing nitrate flux.
-    It is proportional to the amount of organic matter sinking out of the domain.
-    Further improvements to oxygen in the model are ongoing.
-  </li>
-</ul>
-
-<h4>References</h4>
-<p>
-  Stang C. and Allen S.E., 2024.
-  Seasonably variable estuarine exchange through inter-connected channels in the Salish Sea.
-  ESS Open Archive, November 11, 2024.
-  DOI: <a href="https://doi.org/10.22541/essoar.173134323.35470755/v1">https://doi.org/10.22541/essoar.173134323.35470755/v1</a>
-</p>
-<p>
-  Morrison, J., Foreman, M. G. G., & Masson, D., 2012.
-  A Method for Estimating Monthly Freshwater Discharge Affecting British Columbia Coastal Waters. Atmosphere-Ocean, 50(1), 1–8.
-  <a href="https://doi.org/10.1080/07055900.2011.637667">https://doi.org/10.1080/07055900.2011.637667</a>
-</p>
-<p>
-  Moore-Maley, B. L., 2022.
-  Wind-driven upwelling and nutrient supply in a productive estuarine sea.
-  University of British Columbia.
-  <a href="https://open.library.ubc.ca/collections/ubctheses/24/items/1.0418447">https://open.library.ubc.ca/collections/ubctheses/24/items/1.0418447</a>
-</p>
-
-<h2>Citing SalishSeaCast Datasets</h2>
-<p>
-  If you use datasets from this ERDDAP server in your research,
-  please reference it with wording similar to these examples,
-  and include citations of the publications below.
-</p>
-<p>
-  Example reference for physics-only datasets:
-</p>
-<blockquote>
-  Velocity, temperature, and salinity fields from the SalishSeaCast model
-  (Soontiens et al, 2016; Soontiens and Allen, 2017) were downloaded from their ERDDAP server
-  (https://salishsea.eos.ubc.ca/erddap/) on <code>DATE</code> from datasets: <code>DATASETID</code>, <code>DATASETID</code>, ...
-</blockquote>
-<p>
-  Example reference for biological and dissolved oxygen datasets:
-</p>
-<blockquote>
-  Nitrate, silicon, and phytoplankton fields from the SalishSeaCast model
-  (Soontiens et al, 2016; Soontiens and Allen, 2017; Olson et al, 2020)
-  were downloaded from their ERDDAP server (https://salishsea.eos.ubc.ca/erddap/) on <code>DATE</code>
-  from datasets: <code>DATASETID</code>, <code>DATASETID</code>, ...
-</blockquote>
-<p>
-  Example reference for zooplankton datasets:
-</p>
-<blockquote>
-  Zooplankton fields from the SalishSeaCast model
-  (Soontiens et al, 2016; Soontiens and Allen, 2017; Olson et al, 2020; Suchy et al, 2023)
-  were downloaded from their ERDDAP server (https://salishsea.eos.ubc.ca/erddap/) on <code>DATE</code>
-  from datasets: <code>DATASETID</code>, <code>DATASETID</code>, ...
-</blockquote>
-<p>
-  Example reference for carbon chemistry datasets:
-</p>
-<blockquote>
-  Dissolved inorganic carbon, total alkalinity, and surface CO2 flux fields from the SalishSeaCast
-  model (Soontiens et al, 2016; Moore-Maley et al, 2016; Soontiens and Allen, 2017; Olson et al, 2020; Jarníková et al, 2022)
-  were downloaded from their ERDDAP server (https://salishsea.eos.ubc.ca/erddap/) on <code>DATE</code>
-  from datasets: <code>DATASETID</code>, <code>DATASETID</code>, ...
-</blockquote>
-<p>
-  In any of those cases,
-  you substitute in the <code>DATE</code>(s) on which you downloaded the fields,
-  and the <code>DATASETID</code>(s) you downloaded from.
-  The <code>DATE</code>(s) and <code>DATASETID</code>(s) help to ensure reproducibility of your work.
-  <code>DATASETID</code>(s) look like <code>ubcSSg3DTracerFields1hV21-11</code> and are listed in
-  the rightmost column of the table at
-  <a href="https://salishsea.eos.ubc.ca/erddap/info/index.html">https://salishsea.eos.ubc.ca/erddap/info/index.html</a>
-</p>
-
-<h3>Publications to Cite</h3>
-<p>
-  Suchy, K.D., Olson, E.M., Allen, S.E., Galbraith, M., Herrmann, B., Keister, J.E., Perry, R.I., Sastri, A.R., Young, K., 2023.
-  Seasonal and regional variability of model-based zooplankton biomass in the Salish Sea and evaluation against observations.
-  Progress in Oceanography, 219, 103171.
-  <a href="https://doi.org/10.1016/j.pocean.2023.103171">https://doi.org/10.1016/j.pocean.2023.103171</a>
-</p>
-<p>
-  Jarníková, T., Ianson, D., Allen, S.E., Shao, A.E., Olson, E.M., 2022.
-  Anthropogenic carbon increase has caused critical shifts in aragonite saturation across a sensitive coastal system.
-  Global Biogeochemical Cycles, 36(7).
-  <a href="https://doi.org/10.1029/2021GB007024">https://doi.org/10.1029/2021GB007024</a>
-</p>
-<p>
-  Olson, E. M., Allen, S. E., Do, Vy, Dunphy, M., and Ianson, D., 2020.
-  Assessment of Nutrient Supply by a Tidal Jet in the Northern Strait of Georgia Based on a Biogeochemical Model.
-  J. Geophys. Res. Oceans 125(8).
-  <a href="https://doi.org/10.1029/2019JC015766">https://doi.org/10.1029/2019JC015766</a>
-</p>
-<p>
-  Soontiens, N. and Allen, S., 2017.
-  Modelling sensitivities to mixing and advection in a sill-basin estuarine system.
-  Ocean Modelling, 112, 17-32.
-  <a href="https://dx.doi.org/10.1016/j.ocemod.2017.02.008">https://dx.doi.org/10.1016/j.ocemod.2017.02.008</a>
-</p>
-<p>
-  Soontiens, N., Allen, S., Latornell, D., Le Souef, K., Machuca, I., Paquin, J.-P., Lu, Y., Thompson, K., Korabel, V., 2016.
-  Storm surges in the Strait of Georgia simulated with a regional model.
-  Atmosphere-Ocean, 54, 1-21.
-  <a href="https://dx.doi.org/10.1080/07055900.2015.1108899">https://dx.doi.org/10.1080/07055900.2015.1108899</a>
-</p>
-<p>
-  Moore-Maley, B. L., Allen, S. E., and Ianson, D., 2016.
-  Locally-driven interannual variability of near-surface pH and ΩA in the Strait of Georgia.
-  J. Geophys. Res. Oceans, 121(3), 1600–1625.
-  <a href="https://dx.doi.org/10.1002/2015JC011118">https://dx.doi.org/10.1002/2015JC011118</a>
-</p>
-
-[standardShortDescriptionHtml]
-
-]]></theShortDescriptionHtml>
+<useSharedWatchService>true</useSharedWatchService>
+<useSaxParser>true</useSaxParser>
+<usePrometheusMetrics>true</usePrometheusMetrics>
 
 
 </erddapSetup>


### PR DESCRIPTION
* Move many tags from `setup.xml` to `datasets.xml` (via `prefix.xml`).
That allows changes to them to take effect when `datasets.xml` is
next loaded (15 to 60 minutes by default). In particular, the index
page content can now be updated without restarting the server
process.

* Add new v2.00 tags to `prefix.xml`.

* Add `setenv.sh` to track environment variables settings for Java and `tomcat`