### PR TITLE
Increase n*Threads from 1 to 3

### DIFF
--- a/datasets.xml
+++ b/datasets.xml
@@ -11,8 +11,8 @@
 <loadDatasetsMinMinutes>15</loadDatasetsMinMinutes>                 <!-- usually=default=15 -->
 <loadDatasetsMaxMinutes>60</loadDatasetsMaxMinutes>                 <!-- default=60 -->
 <logLevel>info</logLevel>                                           <!-- "warning" (fewest messages), "info" (default), or "all" (most messages) -->
-<nGridThreads>1</nGridThreads>                                      <!-- default=1 -->
-<nTableThreads>1</nTableThreads>                                    <!-- default=1 -->
+<nGridThreads>3</nGridThreads>                                      <!-- default=1 -->
+<nTableThreads>3</nTableThreads>                                    <!-- default=1 -->
 <partialRequestMaxBytes>490000000</partialRequestMaxBytes>          <!-- default=490000000 -->
 <partialRequestMaxCells>10000000</partialRequestMaxCells>           <!-- default=10000000 -->
 <slowDownTroubleMillis>1000</slowDownTroubleMillis>                 <!-- default=1000 -->
@@ -362,6 +362,7 @@ This product does not meet the requirements of Charts and Nautical Publications 
 1995 under the Canadian Shipping Act, 2001.
 Official charts and publications, corrected and up-to-data,
 must be used to meet the requirements of those regulations.</att>
+    <att name="drawLandMask">over</att>
     <att name="institution">UBC EOAS</att>
     <att name="institution_fullname">Dept of Earth, Ocean &amp; Atmospheric Sciences, University of British Columbia</att>
     <att name="infoUrl">https://salishsea.eos.ubc.ca/</att>

--- a/datasets/prefix.xml
+++ b/datasets/prefix.xml
@@ -11,8 +11,8 @@
 <loadDatasetsMinMinutes>15</loadDatasetsMinMinutes>                 <!-- usually=default=15 -->
 <loadDatasetsMaxMinutes>60</loadDatasetsMaxMinutes>                 <!-- default=60 -->
 <logLevel>info</logLevel>                                           <!-- "warning" (fewest messages), "info" (default), or "all" (most messages) -->
-<nGridThreads>1</nGridThreads>                                      <!-- default=1 -->
-<nTableThreads>1</nTableThreads>                                    <!-- default=1 -->
+<nGridThreads>3</nGridThreads>                                      <!-- default=1 -->
+<nTableThreads>3</nTableThreads>                                    <!-- default=1 -->
 <partialRequestMaxBytes>490000000</partialRequestMaxBytes>          <!-- default=490000000 -->
 <partialRequestMaxCells>10000000</partialRequestMaxCells>           <!-- default=10000000 -->
 <slowDownTroubleMillis>1000</slowDownTroubleMillis>                 <!-- default=1000 -->


### PR DESCRIPTION
Increased the `nGridThreads `and `nTableThreads` settings from 1 to 3 as recommended in the v2.19 update notes.