### PR TITLE
Add time to cdm_timeseries_variables attr

### DIFF
--- a/datasets.xml
+++ b/datasets.xml
@@ -10,12 +10,12 @@
 <graphBackgroundColor></graphBackgroundColor>                       <!-- 0xAARRGGBB, default is 0xffccccff -->
 <ipAddressMaxRequests>15</ipAddressMaxRequests>                     <!-- current default=15 -->
 <ipAddressMaxRequestsActive>2</ipAddressMaxRequestsActive>          <!-- current default=2 -->
-<ipAddressUnlimited></ipAddressUnlimited>                           <!-- default=empty -->
+<ipAddressUnlimited>206.12.127.34</ipAddressUnlimited>              <!-- default=empty -->
 <loadDatasetsMinMinutes>15</loadDatasetsMinMinutes>                 <!-- usually=default=15 -->
 <loadDatasetsMaxMinutes>60</loadDatasetsMaxMinutes>                 <!-- default=60 -->
 <logLevel>info</logLevel>                                           <!-- "warning" (fewest messages), "info" (default), or "all" (most messages) -->
-<nGridThreads>3</nGridThreads>                                      <!-- default=1 -->
-<nTableThreads>3</nTableThreads>                                    <!-- default=1 -->
+<nGridThreads>1</nGridThreads>                                      <!-- default=1 -->
+<nTableThreads>1</nTableThreads>                                    <!-- default=1 -->
 <partialRequestMaxBytes>490000000</partialRequestMaxBytes>          <!-- default=490000000 -->
 <partialRequestMaxCells>10000000</partialRequestMaxCells>           <!-- default=10000000 -->
 <slowDownTroubleMillis>1000</slowDownTroubleMillis>                 <!-- default=1000 -->
@@ -10641,7 +10641,7 @@ Digital Research Alliance of Canada</att>
   <addAttributes>
     <att name="testOutOfDate">now-2days</att>
     <att name="cdm_data_type">TimeSeries</att>
-    <att name="cdm_timeseries_variables">depth, longitude, latitude</att>
+    <att name="cdm_timeseries_variables">time, depth, longitude, latitude</att>
     <att name="Conventions">CF-1.6, COARDS, ACDD-1.3</att>
     <att name="creator_name">SalishSeaCast Project Contributors</att>
     <att name="creator_email">sallen@eos.ubc.ca</att>
@@ -10891,7 +10891,7 @@ Store as netCDF4 file.
   <addAttributes>
     <att name="testOutOfDate">now-2days</att>
     <att name="cdm_data_type">TimeSeries</att>
-    <att name="cdm_timeseries_variables">depth, longitude, latitude</att>
+    <att name="cdm_timeseries_variables">time, depth, longitude, latitude</att>
     <att name="Conventions">CF-1.6, COARDS, ACDD-1.3</att>
     <att name="creator_name">SalishSeaCast Project Contributors</att>
     <att name="creator_email">sallen@eos.ubc.ca</att>
@@ -11140,7 +11140,7 @@ Store as netCDF4 file.
     -->
   <addAttributes>
     <att name="cdm_data_type">TimeSeries</att>
-    <att name="cdm_timeseries_variables">depth, longitude, latitude</att>
+    <att name="cdm_timeseries_variables">time, depth, longitude, latitude</att>
     <att name="Conventions">CF-1.6, COARDS, ACDD-1.3</att>
     <att name="creator_name">SalishSeaCast Project Contributors</att>
     <att name="creator_email">sallen@eos.ubc.ca</att>
@@ -11389,7 +11389,7 @@ Store as netCDF4 file.
     -->
   <addAttributes>
     <att name="cdm_data_type">TimeSeries</att>
-    <att name="cdm_timeseries_variables">depth, longitude, latitude</att>
+    <att name="cdm_timeseries_variables">time, depth, longitude, latitude</att>
     <att name="Conventions">CF-1.6, COARDS, ACDD-1.3</att>
     <att name="creator_name">SalishSeaCast Project Contributors</att>
     <att name="creator_email">sallen@eos.ubc.ca</att>
@@ -11636,7 +11636,7 @@ count as aggregation functions.
   <addAttributes>
     <att name="testOutOfDate">now-2days</att>
     <att name="cdm_data_type">TimeSeries</att>
-    <att name="cdm_timeseries_variables">longitude, latitude, on_crossing_mask, crossing_number</att>
+    <att name="cdm_timeseries_variables">time, longitude, latitude</att>
     <att name="Conventions">CF-1.6, COARDS, ACDD-1.3</att>
     <att name="infoUrl">https://salishsea.eos.ubc.ca/</att>
     <att name="institution">UBC EOAS</att>
@@ -13043,6 +13043,8 @@ Store as netCDF4 file.
   -->
   <addAttributes>
     <att name="testOutOfDate">now-2days</att>
+    <att name="cdm_data_type">TimeSeries</att>
+    <att name="cdm_timeseries_variables">time, longitude, latitude</att>
     <att name="Conventions">CF-1.6, COARDS, ACDD-1.3</att>
     <att name="creator_name">SalishSeaCast Project Contributors</att>
     <att name="creator_email">sallen@eos.ubc.ca</att>

--- a/datasets/2ndNarrowsHADCP-observations/ubcVFPA2ndNarrowsCurrent2sV1.xml
+++ b/datasets/2ndNarrowsHADCP-observations/ubcVFPA2ndNarrowsCurrent2sV1.xml
@@ -30,6 +30,8 @@
   -->
   <addAttributes>
     <att name="testOutOfDate">now-2days</att>
+    <att name="cdm_data_type">TimeSeries</att>
+    <att name="cdm_timeseries_variables">time, longitude, latitude</att>
     <att name="Conventions">CF-1.6, COARDS, ACDD-1.3</att>
     <att name="creator_name">SalishSeaCast Project Contributors</att>
     <att name="creator_email">sallen@eos.ubc.ca</att>

--- a/datasets/onc-observations/ubcONCLSBBLCTD15mV1.xml
+++ b/datasets/onc-observations/ubcONCLSBBLCTD15mV1.xml
@@ -33,7 +33,7 @@
     -->
   <addAttributes>
     <att name="cdm_data_type">TimeSeries</att>
-    <att name="cdm_timeseries_variables">depth, longitude, latitude</att>
+    <att name="cdm_timeseries_variables">time, depth, longitude, latitude</att>
     <att name="Conventions">CF-1.6, COARDS, ACDD-1.3</att>
     <att name="creator_name">SalishSeaCast Project Contributors</att>
     <att name="creator_email">sallen@eos.ubc.ca</att>

--- a/datasets/onc-observations/ubcONCSCVIPCTD15mV1.xml
+++ b/datasets/onc-observations/ubcONCSCVIPCTD15mV1.xml
@@ -34,7 +34,7 @@
   <addAttributes>
     <att name="testOutOfDate">now-2days</att>
     <att name="cdm_data_type">TimeSeries</att>
-    <att name="cdm_timeseries_variables">depth, longitude, latitude</att>
+    <att name="cdm_timeseries_variables">time, depth, longitude, latitude</att>
     <att name="Conventions">CF-1.6, COARDS, ACDD-1.3</att>
     <att name="creator_name">SalishSeaCast Project Contributors</att>
     <att name="creator_email">sallen@eos.ubc.ca</att>

--- a/datasets/onc-observations/ubcONCSEVIPCTD15mV1.xml
+++ b/datasets/onc-observations/ubcONCSEVIPCTD15mV1.xml
@@ -34,7 +34,7 @@
   <addAttributes>
     <att name="testOutOfDate">now-2days</att>
     <att name="cdm_data_type">TimeSeries</att>
-    <att name="cdm_timeseries_variables">depth, longitude, latitude</att>
+    <att name="cdm_timeseries_variables">time, depth, longitude, latitude</att>
     <att name="Conventions">CF-1.6, COARDS, ACDD-1.3</att>
     <att name="creator_name">SalishSeaCast Project Contributors</att>
     <att name="creator_email">sallen@eos.ubc.ca</att>

--- a/datasets/onc-observations/ubcONCTWDP1mV18-01.xml
+++ b/datasets/onc-observations/ubcONCTWDP1mV18-01.xml
@@ -31,7 +31,7 @@ count as aggregation functions.
   <addAttributes>
     <att name="testOutOfDate">now-2days</att>
     <att name="cdm_data_type">TimeSeries</att>
-    <att name="cdm_timeseries_variables">longitude, latitude, on_crossing_mask, crossing_number</att>
+    <att name="cdm_timeseries_variables">time, longitude, latitude</att>
     <att name="Conventions">CF-1.6, COARDS, ACDD-1.3</att>
     <att name="infoUrl">https://salishsea.eos.ubc.ca/</att>
     <att name="institution">UBC EOAS</att>

--- a/datasets/onc-observations/ubcONCUSDDLCTD15mV1.xml
+++ b/datasets/onc-observations/ubcONCUSDDLCTD15mV1.xml
@@ -33,7 +33,7 @@
     -->
   <addAttributes>
     <att name="cdm_data_type">TimeSeries</att>
-    <att name="cdm_timeseries_variables">depth, longitude, latitude</att>
+    <att name="cdm_timeseries_variables">time, depth, longitude, latitude</att>
     <att name="Conventions">CF-1.6, COARDS, ACDD-1.3</att>
     <att name="creator_name">SalishSeaCast Project Contributors</att>
     <att name="creator_email">sallen@eos.ubc.ca</att>


### PR DESCRIPTION
Time series datasets must include in their `cdm_timeseries_variables` the variable with `cf_role=timeseries_id`.