### PR TITLE
Update Python version to 3.13 in envs & workflows

### DIFF
--- a/.github/workflows/check-datasets-xml.yaml
+++ b/.github/workflows/check-datasets-xml.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.12' ]
+        python-version: [ '3.13' ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,8 @@
         "pyyaml",
         "structlog"
     ],
-    "esbonio.sphinx.confDir": ""
+    "esbonio.sphinx.confDir": "",
+    "python-envs.defaultEnvManager": "ms-python.python:conda",
+    "python-envs.defaultPackageManager": "ms-python.python:conda",
+    "python-envs.pythonProjects": []
 }

--- a/envs/environment-dev.yaml
+++ b/envs/environment-dev.yaml
@@ -17,7 +17,7 @@ dependencies:
   - lxml
   - netcdf4
   - pip
-  - python=3.12
+  - python=3.13
   - pyyaml
   - rich
   - structlog

--- a/envs/environment-test.yaml
+++ b/envs/environment-test.yaml
@@ -12,7 +12,7 @@ channels:
 dependencies:
   - lxml
   - pip
-  - python=3.12
+  - python=3.13
   - pyyaml
   - rich
   - structlog


### PR DESCRIPTION
- Changed Python version from 3.12 to 3.13 in .github/workflows/check-datasets-xml.yaml
- Updated Python version from 3.12 to 3.13 in envs/environment-dev.yaml
- Updated Python version from 3.12 to 3.13 in envs/environment-test.yaml
- Updated VSCode settings to use conda as the default environment manager and package manager